### PR TITLE
Add support for skiptags filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var tagFilter = require("./lib/tag_filter");
 var groupFilter = require("./lib/group_filter");
 var singleTestFilter = require("./lib/single_test_filter");
 var fileFilter = require("./lib/file_filter");
+var skipTagFilter = require('./lib/skip_tag_filter');
 
 var plugin = {
   initialize: function (argv, options) {
@@ -9,9 +10,11 @@ var plugin = {
   },
   iterator: require("./lib/get_tests"),
   filters: {
+    group: groupFilter,
     tag: tagFilter,
     tags: tagFilter,
-    group: groupFilter,
+    skiptag: skipTagFilter,
+    skiptags: skipTagFilter,
     test: singleTestFilter,
     testFile: fileFilter
   },

--- a/lib/is_matched.js
+++ b/lib/is_matched.js
@@ -1,0 +1,64 @@
+var path = require("path"),
+  fs = require("fs"),
+  acorn = require("acorn"),
+  clc = require("cli-color"),
+  walk = require("acorn-walk"),
+  logger = require("./logger");
+
+module.exports =  function (tags, f) {
+  // Filter by tag (or tag list):
+  //
+  // Parse the syntax tree of each included test and search for a property
+  // definition with the name "tags" with an array expression attached to it,
+  // i.e. we're looking for source code in the following form:
+  //
+  //    tags: [ value, value, value ]
+  //
+  // Match each f in files against the tag list we have in the array tags.
+  //
+  var foundTags = false;
+  var pass = false;
+  var filename = path.resolve(f);
+  var root;
+  try {
+    root = acorn.parse(fs.readFileSync(filename));
+  } catch (err) {
+    logger.log(clc.redBright("Syntax error in parsing " + filename));
+    throw err;
+  }
+
+  walk.findNodeAt(root, null, null, function (nodeType, node) {
+    // Don't continue scanning if we've already passed or if we've already
+    // found the tags: [] structure.
+    if (!foundTags && !pass) {
+      if (nodeType === "Property"
+        && node.key
+        && (node.key.name === "tags"        // for tags: []
+          || node.key.value === "@tags"     // for "@tags": []
+          || node.key.value === "tags")     // for "tags": []
+        && node.value
+        && node.value.type === "ArrayExpression"
+        && node.value.elements) {
+        foundTags = true;
+
+        // Collect the tags this test matches
+        var localTags = [];
+        node.value.elements.forEach(function (tagNode) {
+          if (tagNode.value && typeof tagNode.value === "string") {
+            localTags.push(tagNode.value.trim());
+          }
+        });
+
+        // check if each of tags exists in this test case (in localTags)
+        if (tags.every(function (wantedTag) {
+          return localTags.indexOf(wantedTag) > -1;
+        })) {
+          pass = true;
+        }
+
+      }
+    }
+  });
+
+  return pass;
+};

--- a/lib/skip_tag_filter.js
+++ b/lib/skip_tag_filter.js
@@ -1,6 +1,7 @@
-var _ = require("lodash"),
-  logger = require("./logger"),
-  isMatched = require('./is_matched');
+var logger = require("./logger"),
+  _ = require("lodash"),
+  isMatched = require("./is_matched");
+
 
 module.exports = function (tests, tags) {
   // Tidy up tag input. If we have a comma-delimited list, tokenize and clean it up
@@ -22,8 +23,8 @@ module.exports = function (tests, tags) {
     return tests;
   }
 
-  logger.log("Using nightwatch tag filter with tags: " + tags);
+  logger.log("Using nightwatch skiptags filter with tags: " + tags);
   return tests.filter(function (test) {
-    return isMatched(tags, test.filename);
+    return !isMatched(tags, test.filename);
   });
 };

--- a/test/test_filtering.js
+++ b/test/test_filtering.js
@@ -11,6 +11,7 @@ var tagFilter = testFramework.filters.tag;
 var singleFilter = testFramework.filters.test;
 var groupFilter = testFramework.filters.group;
 var fileFilter = testFramework.filters.testFile;
+var skipTagFilter = testFramework.filters.skiptag;
 
 describe("nightwatch support", function () {
 
@@ -57,7 +58,6 @@ describe("nightwatch support", function () {
   });
 
   describe("tag filter", function () {
-
     it("finds tests with a tag filter", function () {
       var tests = getTests();
       var filteredTests = tagFilter(tests, ["search"]);
@@ -86,6 +86,31 @@ describe("nightwatch support", function () {
       expect(filteredTests).to.have.length(0);
     });
 
+  });
+
+  describe("skiptag filter", function () {
+    it("skips tests with a skiptag filter", function () {
+      var tests = getTests();
+      var filteredTests = skipTagFilter(tests, ["wiki"]);
+
+      expect(filteredTests).to.have.length(2);
+    });
+
+    it("skips no tests with an unmatched tag filter", function () {
+      var tests = getTests();
+      var filteredTests = skipTagFilter(tests, ["xyz000"]);
+
+      expect(filteredTests).to.have.length(3);
+    });
+
+    it("skips tags in combination with a tag filter", function () {
+      var tests = getTests();
+      var filteredTests = tagFilter(tests, ["search"]);
+      var skipTests = skipTagFilter(filteredTests, ["mobile"]);
+
+      expect(filteredTests).to.have.length(2);
+      expect(skipTests).to.have.length(1);
+    })
   });
 
   describe("file test filter", function () {


### PR DESCRIPTION
To improve parity with the tag filtering available in nightwatch, this adds the ability to pass the `skiptags` filtering (see https://nightwatchjs.org/guide/running-tests/#command-line-options). 

- Move tag matching to its own lib file
- Add skiptag tag filtering
- Reorder filters for minor performance improvement